### PR TITLE
added install_zed_sdk to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,13 @@ whl:
 	. venv/bin/activate
 	python3 -m pip install build
 	python3 -m build
+
+.PHONY: install_zed_sdk
+install_zed_sdk:
+	apt-get update
+	apt install sudo
+	apt install -y zip
+	apt install zstd
+	ZED_SDK_INSTALLER=ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run
+	wget --quiet -O ${ZED_SDK_INSTALLER} https://download.stereolabs.com/zedsdk/4.1/l4t35.2/jetsons
+	chmod +x ${ZED_SDK_INSTALLER} && ./${ZED_SDK_INSTALLER} -- silent

--- a/install_zed_sdk.sh
+++ b/install_zed_sdk.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+apt-get update
+apt install sudo
+apt install -y zip
+apt install zstd
+
+ZED_SDK_INSTALLER=ZED_SDK_Tegra_L4T35.3_v4.1.0.zstd.run
+wget --quiet -O ${ZED_SDK_INSTALLER} https://download.stereolabs.com/zedsdk/4.1/l4t35.2/jetsons
+chmod +x ${ZED_SDK_INSTALLER} && ./${ZED_SDK_INSTALLER} -- silent


### PR DESCRIPTION
# why
- There was no install way to install zed sdk non-docker environment.
# what
- Now you can
```
$ make install_zed_sdk
# or
$ sh install_zed_sdk.sh
```

As far as using docker,
docker_build automatically  install zed sdk.