### PR TITLE
Feature/refactor normal

### DIFF
--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -18,7 +18,7 @@ class DepthToNormalMap:
         dy = cv2.Sobel(depth_map, cv2.CV_32F, 0, 1)
 
         # Compute the normal vector for each pixel
-        z_value = 0.1 * np.mean(np.sqrt(dx**2 + dy**2))
+        z_value = 0.1 * np.percentile(np.sqrt(dx**2 + dy**2), 50)  # median
         normal = np.dstack((-dx, -dy, np.full((rows, cols), z_value)))
         # sqrt(dx**2 + dy**2 + z_value**2) を計算している
         norm = np.sqrt(np.sum(normal**2, axis=2, keepdims=True))

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -25,20 +25,14 @@ class DepthToNormalMap:
         # Calculate the partial derivatives of depth with respect to x and y
         dx = cv2.Sobel(depth_map, cv2.CV_32F, 1, 0)
         dy = cv2.Sobel(depth_map, cv2.CV_32F, 0, 1)
-        print(f"{np.max(dx.flatten())=}")
-        print(f"{np.max(dy.flatten())=}")
-        print(f"{np.percentile(dx.flatten(), [90])=}")
-        print(f"{np.percentile(dy.flatten(), [90])=}")
 
         # Compute the normal vector for each pixel
         scale = 0.1 * np.mean(np.sqrt(dx**2 + dy**2))
-        # scale = 0.01
-        print(f"{scale=}")
         normal = np.dstack((-dx, -dy, np.full((rows, cols), scale)))
-        print(f"{normal.shape=}")
         # sqrt(dx**2 + dy**2 + 1**2) を計算している
         norm = np.sqrt(np.sum(normal**2, axis=2, keepdims=True))
-        print(f"{norm.shape=}")
+
+        # それぞれの画素についてRGBのベクトルの大きさが１になるようにしている。
         normal = np.divide(normal, norm, out=np.zeros_like(normal), where=norm != 0)
 
         # Map the normal vectors to the [0, 255] range and convert to uint8

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -18,9 +18,9 @@ class DepthToNormalMap:
         dy = cv2.Sobel(depth_map, cv2.CV_32F, 0, 1)
 
         # Compute the normal vector for each pixel
-        scale = 0.1 * np.mean(np.sqrt(dx**2 + dy**2))
-        normal = np.dstack((-dx, -dy, np.full((rows, cols), scale)))
-        # sqrt(dx**2 + dy**2 + 1**2) を計算している
+        z_value = 0.1 * np.mean(np.sqrt(dx**2 + dy**2))
+        normal = np.dstack((-dx, -dy, np.full((rows, cols), z_value)))
+        # sqrt(dx**2 + dy**2 + z_value**2) を計算している
         norm = np.sqrt(np.sum(normal**2, axis=2, keepdims=True))
 
         # それぞれの画素についてRGBのベクトルの大きさが１になるようにしている。

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -27,7 +27,9 @@ class DepthToNormalMap:
 
         # Compute the normal vector for each pixel
         normal = np.dstack((-dx, -dy, np.ones((rows, cols))))
-        norm = np.sqrt(np.sum(normal**2, axis=2, keepdims=True))
+        print(f"{normal.shape=}")
+        norm = np.sqrt(np.mean(normal**2, axis=2, keepdims=True))
+        print(f"{norm=}")
         normal = np.divide(normal, norm, out=np.zeros_like(normal), where=norm != 0)
 
         # Map the normal vectors to the [0, 255] range and convert to uint8

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 import cv2
 import numpy as np
+import skimage.util
 
 
 @dataclass
@@ -30,9 +31,11 @@ class DepthToNormalMap:
         print(f"{np.percentile(dy.flatten(), [90])=}")
 
         # Compute the normal vector for each pixel
-        normal = np.dstack((-dx, -dy, np.ones((rows, cols))))
+        scale = 0.01
+        normal = np.dstack((-dx, -dy, np.full((rows, cols), scale)))
         print(f"{normal.shape=}")
-        norm = np.sqrt(np.mean(normal**2, axis=2, keepdims=True))
+        # sqrt(dx**2 + dy**2 + 1**2) を計算している
+        norm = np.sqrt(np.sum(normal**2, axis=2, keepdims=True))
         print(f"{norm.shape=}")
         normal = np.divide(normal, norm, out=np.zeros_like(normal), where=norm != 0)
 

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -31,7 +31,9 @@ class DepthToNormalMap:
         print(f"{np.percentile(dy.flatten(), [90])=}")
 
         # Compute the normal vector for each pixel
-        scale = 0.01
+        scale = 0.1 * np.mean(np.sqrt(dx**2 + dy**2))
+        # scale = 0.01
+        print(f"{scale=}")
         normal = np.dstack((-dx, -dy, np.full((rows, cols), scale)))
         print(f"{normal.shape=}")
         # sqrt(dx**2 + dy**2 + 1**2) を計算している

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -7,20 +7,11 @@ import skimage.util
 
 @dataclass
 class DepthToNormalMap:
-    """A class for converting a depth map image to a normal map image.
-
-
-    """
+    """A class for converting a depth map image to a normal map image."""
 
     def convert(self, depth_map: np.ndarray) -> np.ndarray:
-        """Converts the depth map image to a normal map image.
-
-        """
+        """Converts the depth map image to a normal map image."""
         rows, cols = depth_map.shape[:2]
-
-        x, y = np.meshgrid(np.arange(cols), np.arange(rows))
-        x = x.astype(np.float32)
-        y = y.astype(np.float32)
 
         # Calculate the partial derivatives of depth with respect to x and y
         dx = cv2.Sobel(depth_map, cv2.CV_32F, 1, 0)

--- a/disparity_view/depth_to_normal.py
+++ b/disparity_view/depth_to_normal.py
@@ -24,12 +24,16 @@ class DepthToNormalMap:
         # Calculate the partial derivatives of depth with respect to x and y
         dx = cv2.Sobel(depth_map, cv2.CV_32F, 1, 0)
         dy = cv2.Sobel(depth_map, cv2.CV_32F, 0, 1)
+        print(f"{np.max(dx.flatten())=}")
+        print(f"{np.max(dy.flatten())=}")
+        print(f"{np.percentile(dx.flatten(), [90])=}")
+        print(f"{np.percentile(dy.flatten(), [90])=}")
 
         # Compute the normal vector for each pixel
         normal = np.dstack((-dx, -dy, np.ones((rows, cols))))
         print(f"{normal.shape=}")
         norm = np.sqrt(np.mean(normal**2, axis=2, keepdims=True))
-        print(f"{norm=}")
+        print(f"{norm.shape=}")
         normal = np.divide(normal, norm, out=np.zeros_like(normal), where=norm != 0)
 
         # Map the normal vectors to the [0, 255] range and convert to uint8

--- a/scripts/view_npy.py
+++ b/scripts/view_npy.py
@@ -31,20 +31,20 @@ if __name__ == "__main__":
     elif Path(args.npy_file).is_dir():
         npys = sorted(Path(args.npy_file).glob("*.npy"))
 
+    baseline = 120.0  # [mm] baseline value for ZED2i case
     for npy in tqdm(npys):
         disparity = np.load(npy)
-        print(f"{np.nanmax(disparity.flatten())=}")
-        print(f"{np.nanmin(disparity.flatten())=}")
+
         minval = np.nanmin(disparity.flatten())
         if args.normal:
-            print(f"{args.normal=}")
             converter = disparity_view.DepthToNormalMap()
-            depth_map = 1.0 / disparity
-            depth_map[np.logical_not(np.isfinite(depth_map))] = 1.0 / minval
+            depth_map = baseline / disparity
+            # padded to remove non-finite values
+            depth_map[np.logical_not(np.isfinite(depth_map))] = baseline / minval
             normal_bgr = converter.convert(depth_map)
-            print(f"{normal_bgr.shape=}")
             oname = Path(args.outdir) / f"normal_{npy.stem}.png"
             oname.parent.mkdir(exist_ok=True)
             cv2.imwrite(str(oname), normal_bgr)
+            print(f"saved {oname}")
         else:
             view_npy(disparity, args)

--- a/test/test_depth_to_normal_map.py
+++ b/test/test_depth_to_normal_map.py
@@ -2,6 +2,7 @@ import cv2
 
 import disparity_view
 
+
 def test_depth2normal():
     input_name = "assets/depth.png"
     converter = disparity_view.DepthToNormalMap()


### PR DESCRIPTION
# why
- normal が等高線のようにだけしか表示されないという不具合があった。
# what
- コードの意味を読むようにした。
(dx, dy, z_value) のなすベクトルの大きさが、dx, dy の値の変化によって十分に変わるように、z_valueの値を取り直した。
元のコードでは、(dx, dy, 1.0) なので、dx, dyの変化が1.0　より桁が小さいと、変化が見られなくなってしまっていた。

- scripts/view_npy.py では depth_map = baseline / disparity　とするようにした。

# example
![normal_left_motorcycle](https://github.com/user-attachments/assets/1a7895d9-33fc-4639-b25e-76471bffe929)
