### PR TITLE
adding rvecs

### DIFF
--- a/disparity_view/reprojection.py
+++ b/disparity_view/reprojection.py
@@ -52,7 +52,7 @@ def reproject_point_cloud(
     """
 
     # カメラ座標系から画像座標系に変換 (投影)
-    points_2d, _ = cv2.projectPoints(point_cloud, rvecs, tvec, right_camera_intrinsics, np.zeros(5))
+    points_2d, _ = cv2.projectPoints(point_cloud, rvec=rvecs, tvec=tvec, cameraMatrix=right_camera_intrinsics, distCoeffs=np.zeros(5))
     points_2d = np.int32(points_2d).reshape(-1, 2)
 
     # 再投影画像の作成

--- a/disparity_view/reprojection.py
+++ b/disparity_view/reprojection.py
@@ -36,7 +36,7 @@ def generate_point_cloud(disparity_map: np.ndarray, left_image: np.ndarray, came
 
 
 def reproject_point_cloud(
-    point_cloud: np.ndarray, color: np.ndarray, right_camera_intrinsics: np.ndarray, tvec=np.zeros(3, dtype=np.float32)
+    point_cloud: np.ndarray, color: np.ndarray, right_camera_intrinsics: np.ndarray, rvecs=np.eye(3, dtype=np.float32), tvec=np.zeros(3, dtype=np.float32)
 ) -> np.ndarray:
     """
     点群データを右カメラ視点に再投影する関数
@@ -52,7 +52,7 @@ def reproject_point_cloud(
     """
 
     # カメラ座標系から画像座標系に変換 (投影)
-    points_2d, _ = cv2.projectPoints(point_cloud, np.zeros(3), tvec, right_camera_intrinsics, np.zeros(5))
+    points_2d, _ = cv2.projectPoints(point_cloud, rvecs, tvec, right_camera_intrinsics, np.zeros(5))
     points_2d = np.int32(points_2d).reshape(-1, 2)
 
     # 再投影画像の作成
@@ -75,6 +75,7 @@ def reproject_from_left_and_disparity(
     disparity: np.ndarray,
     camera_matrix: np.ndarray,
     baseline: float,
+    rvecs=np.eye(3, dtype=np.float32),
     tvec=np.zeros(3, dtype=np.float32),
 ) -> np.ndarray:
     """
@@ -92,4 +93,4 @@ def reproject_from_left_and_disparity(
     right_camera_intrinsics = camera_matrix
 
     point_cloud, color = generate_point_cloud(disparity, left_image, camera_matrix, baseline)
-    return reproject_point_cloud(point_cloud, color, right_camera_intrinsics, tvec=tvec)
+    return reproject_point_cloud(point_cloud, color, right_camera_intrinsics, rvecs=rvecs, tvec=tvec)

--- a/disparity_view/reprojection.py
+++ b/disparity_view/reprojection.py
@@ -36,7 +36,7 @@ def generate_point_cloud(disparity_map: np.ndarray, left_image: np.ndarray, came
 
 
 def reproject_point_cloud(
-    point_cloud: np.ndarray, color: np.ndarray, right_camera_intrinsics: np.ndarray, rvecs=np.eye(3, dtype=np.float32), tvec=np.zeros(3, dtype=np.float32)
+    point_cloud: np.ndarray, color: np.ndarray, right_camera_intrinsics: np.ndarray, rvec=np.eye(3, dtype=np.float64), tvec=np.zeros(3, dtype=np.float64)
 ) -> np.ndarray:
     """
     点群データを右カメラ視点に再投影する関数
@@ -52,7 +52,8 @@ def reproject_point_cloud(
     """
 
     # カメラ座標系から画像座標系に変換 (投影)
-    points_2d, _ = cv2.projectPoints(point_cloud, rvec=rvecs, tvec=tvec, cameraMatrix=right_camera_intrinsics, distCoeffs=np.zeros(5))
+    dtype = tvec.dtype
+    points_2d, _ = cv2.projectPoints(point_cloud, rvec=rvec, tvec=tvec, cameraMatrix=right_camera_intrinsics, distCoeffs=np.zeros(5, dtype=dtype))
     points_2d = np.int32(points_2d).reshape(-1, 2)
 
     # 再投影画像の作成
@@ -75,8 +76,8 @@ def reproject_from_left_and_disparity(
     disparity: np.ndarray,
     camera_matrix: np.ndarray,
     baseline: float,
-    rvecs=np.eye(3, dtype=np.float32),
-    tvec=np.zeros(3, dtype=np.float32),
+    rvec=np.eye(3, dtype=np.float64),
+    tvec=np.zeros(3, dtype=np.float64),
 ) -> np.ndarray:
     """
     Returns a reprojected image based on the left camera image, disparity image and camera parameters.
@@ -93,4 +94,4 @@ def reproject_from_left_and_disparity(
     right_camera_intrinsics = camera_matrix
 
     point_cloud, color = generate_point_cloud(disparity, left_image, camera_matrix, baseline)
-    return reproject_point_cloud(point_cloud, color, right_camera_intrinsics, rvecs=rvecs, tvec=tvec)
+    return reproject_point_cloud(point_cloud, color, right_camera_intrinsics, rvec=rvec, tvec=tvec)

--- a/scripts/reproject.py
+++ b/scripts/reproject.py
@@ -29,7 +29,7 @@ def gen_right_image(disparity: np.ndarray, left_image: np.ndarray, outdir: Path,
     camera_matrix = dummy_camera_matrix(left_image.shape)
     baseline = 100.0  # [mm] dummy
     tvec = np.array((-baseline, 0.0, 0.0))
-    reprojected_image = reproject_from_left_and_disparity(left_image, disparity, camera_matrix, baseline, tvec)
+    reprojected_image = reproject_from_left_and_disparity(left_image, disparity, camera_matrix, baseline=baseline, tvec=tvec)
     outname = outdir / f"reproject_{left_name.stem}.png"
     outname.parent.mkdir(exist_ok=True, parents=True)
     cv2.imwrite(str(outname), reprojected_image)
@@ -67,7 +67,7 @@ def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Pa
     n = 16
     for i in tqdm(range(n + 1)):
         tvec = np.array((-baseline * i / n, 0.0, 0.0))
-        reprojected_image = reproject_point_cloud(point_cloud, color, right_camera_intrinsics, tvec)
+        reprojected_image = reproject_point_cloud(point_cloud, color, right_camera_intrinsics, tvec=tvec)
         reprojected_image = cv2.cvtColor(reprojected_image, cv2.COLOR_BGR2RGB)
         pil_image = Image.fromarray(reprojected_image)
         pictures.append(pil_image)

--- a/test/test_reproject.py
+++ b/test/test_reproject.py
@@ -30,6 +30,6 @@ def test_reproject_from_left_and_disparity():
 
     baseline = 100.0  # [mm] dummy
     tvec = np.array((-baseline, 0.0, 0.0))
-    reprojected_image = reproject_from_left_and_disparity(left_image, disparity, camera_matrix, baseline, tvec)
+    reprojected_image = reproject_from_left_and_disparity(left_image, disparity, camera_matrix, baseline=baseline, tvec=tvec)
     cv2.imwrite("reprojected.png", reprojected_image)
     assert reprojected_image.shape == left_image.shape


### PR DESCRIPTION
# why
- 並進運動だけでなく、回転もサポートさせたい。
- ベースとなる実装に呼び出し方法をそろえていきたい。
# what
- signature の変更
- rvec=np.eye(3, dtype=np.float64)の追加
- keyword引数の利用
# 動作確認
- 以下のスクリプトを実行した結果のgifファイルを確認した。
python3 reproject.py --gif ../test/test-imgs/disparity-IGEV/left_motorcycle.npy ../test/test-imgs/left/left_motorcycle.png

# 今後の方向性
- OpenCVベースからOpen3Dベースに書き換えていきたい。
- 明示的な型を利用することで、コードの間違いを減らせることを期待している。
