### PR TITLE
added scikit-image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "opencv-python==3.4.18.65",
     "open3d>=0.18.0",
     "pillow",
+    "scikit-image",
     "tqdm",
 ]
 


### PR DESCRIPTION
# why
- skimageを使っているのにpyproject.toml に記載がなかった。
# what
- pyproject.toml にscikit-image を追加した。
