### PR TITLE
use safer_imsave

### DIFF
--- a/disparity_view/o3d_reprojection.py
+++ b/disparity_view/o3d_reprojection.py
@@ -9,7 +9,7 @@ import cv2
 from tqdm import tqdm
 
 from .animation_gif import AnimationGif
-from .util import dummy_camera_matrix
+from .util import dummy_camera_matrix, safer_imsave
 
 
 DEPTH_SCALE = 1000.0
@@ -102,9 +102,9 @@ def gen_right_image(disparity: np.ndarray, left_image: np.ndarray, outdir, left_
     depth_out = outdir / f"depth_{left_name.stem}.png"
     color_out = outdir / f"color_{left_name.stem}.png"
 
-    skimage.io.imsave(str(color_out), color_legacy)
+    safer_imsave(str(color_out), color_legacy)
     print(f"saved {color_out}")
-    skimage.io.imsave(str(depth_out), depth_legacy)
+    safer_imsave(str(depth_out), depth_legacy)
     print(f"saved {depth_out}")
 
 

--- a/scripts/point_cloud_to_rgbd.py
+++ b/scripts/point_cloud_to_rgbd.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import open3d as o3d
 import numpy as np
-import skimage.io
+
+from disparity_view.util import safer_imsave
 
 
 def read_and_reproject(depth_path: str, color_path: str):
@@ -30,8 +31,8 @@ def read_and_reproject(depth_path: str, color_path: str):
     outdir.mkdir(exist_ok=True, parents=True)
     depth_out = outdir / "depth.png"
     color_out = outdir / "color.png"
-    skimage.io.imsave(str(color_out), color_legacy)
-    skimage.io.imsave(str(depth_out), depth_legacy)
+    safer_imsave(str(color_out), color_legacy)
+    safer_imsave(str(depth_out), depth_legacy)
 
     print(f"saved {color_out} {depth_out}")
 

--- a/test/test_o3d_reprojet.py
+++ b/test/test_o3d_reprojet.py
@@ -18,7 +18,7 @@ import skimage.io
 from disparity_view.o3d_reprojection import gen_right_image, make_animation_gif
 import inspect
 
-from disparity_view.util import dummy_pinhole_camera_intrincic
+from disparity_view.util import safer_imsave
 
 
 def shape_of(image) -> Tuple[float, float]:
@@ -107,9 +107,9 @@ def test_o3d_reproject():
     depth_out = outdir / "depth.png"
     color_out = outdir / "color.png"
 
-    skimage.io.imsave(str(color_out), color_legacy)
+    safer_imsave(str(color_out), color_legacy)
     print(f"saved {color_out}")
-    skimage.io.imsave(str(depth_out), depth_legacy)
+    safer_imsave(str(depth_out), depth_legacy)
     print(f"saved {depth_out}")
 
 


### PR DESCRIPTION
# why
- Jetson AGX Orin で動作させようとするとエラーを生じた。
- safer_imsave() をutil.pyに加えてある。
# what
- モジュールでsafer_imsave()を使うように改変した。
# 状況
- 直接float画像をskimage.io.imsave()している関数だけが失敗している。

