### PR TITLE
Feature/gif again

### DIFF
--- a/disparity_view/projection_class.py
+++ b/disparity_view/projection_class.py
@@ -5,10 +5,12 @@ from typing import Tuple
 import cv2
 import numpy as np
 import open3d as o3d
+from tqdm import tqdm
 
-from .util import dummy_camera_matrix
+from .animation_gif import AnimationGif
+from .util import dummy_camera_matrix, safer_imsave
 from .util import safer_imsave
-from .o3d_project import generate_point_cloud
+from .o3d_project import generate_point_cloud, gen_tvec, as_extrinsics
 from .o3d_project import DEPTH_MAX, DEPTH_SCALE
 from .zed_info import CameraParameter
 
@@ -62,3 +64,74 @@ class StereoCamera:
 
     def scaled_baseline(self):
         return self.baseline / DEPTH_SCALE
+
+
+def gen_right_image(disparity, left_image, outdir, left_name, axis=0):
+    stereo_camera = StereoCamera(baseline=120)
+    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
+    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
+    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
+    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
+    extrinsics = as_extrinsics(tvec)
+    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+    color_legacy = np.asarray(projected.color.to_legacy())
+    outfile = outdir / f"color_{left_name.stem}.png"
+    outfile.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(outfile), color_legacy)
+    depth_legacy = np.asarray(projected.depth.to_legacy())
+    depth_file = outdir / f"depth_{left_name.stem}.png"
+    depth_file.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(depth_file), depth_legacy)
+    print(f"saved {outfile}")
+    print(f"saved {depth_file}")
+
+    assert outfile.lstat().st_size > 0
+
+
+def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Path, left_name: Path, axis=0):
+    """
+    save animation gif file
+
+    Args:
+        disparity: disparity image
+        left_image:left camera image
+        outdir: destination directory
+        left_name: file name of the left camera image
+    Returns：
+        None
+    """
+    assert axis in (0, 1, 2)
+
+    stereo_camera = StereoCamera(baseline=120)
+    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
+    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
+    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
+    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
+    extrinsics = as_extrinsics(tvec)
+    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+    color_legacy = np.asarray(projected.color.to_legacy())
+    outfile = outdir / f"color_{left_name.stem}.png"
+    outfile.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(outfile), color_legacy)
+    depth_legacy = np.asarray(projected.depth.to_legacy())
+    depth_file = outdir / f"depth_{left_name.stem}.png"
+    depth_file.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(depth_file), depth_legacy)
+    print(f"saved {outfile}")
+    print(f"saved {depth_file}")
+
+
+    maker = AnimationGif()
+    n = 16
+    for i in tqdm(range(n + 1)):
+        scaled_baseline = stereo_camera.scaled_baseline()
+        tvec = gen_tvec(scaled_baseline * i / n, axis)
+        extrinsics = as_extrinsics(tvec)
+        projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+        color_img = np.asarray(projected.color.to_legacy())
+        color_img = (color_img * 255).astype(np.uint8)
+        maker.append(color_img)
+
+    gifname = outdir / f"reproject_{left_name.stem}.gif"
+    gifname.parent.mkdir(exist_ok=True, parents=True)
+    maker.save(gifname)

--- a/disparity_view/util.py
+++ b/disparity_view/util.py
@@ -33,6 +33,10 @@ def safer_imsave(p: Path, img: np.ndarray):
     int_type = (np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64)
     if img.dtype in int_type:
         skimage.io.imsave(str(p), img)
+    elif str(p).find("depth") > -1:
+        max_val = np.max(img.flatten())
+        uint8_img = np.array(img * 255 / max_val, dtype=np.uint8)
+        skimage.io.imsave(str(p), uint8_img)
     else:
         uint8_img = np.array(img * 255, dtype=np.uint8)
         skimage.io.imsave(str(p), uint8_img)

--- a/scripts/sample_class.py
+++ b/scripts/sample_class.py
@@ -1,12 +1,35 @@
 from pathlib import Path
+
 import numpy as np
+import skimage.io
 
 from disparity_view.o3d_project import gen_tvec, DEPTH_SCALE
 from disparity_view.o3d_project import as_extrinsics
 from disparity_view.projection_class import StereoCamera
 from disparity_view.util import safer_imsave
 
-import skimage.io
+
+def gen_right_image(disparity, left_image, outdir, left_name, axis=0):
+    stereo_camera = StereoCamera(baseline=120)
+    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
+    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
+    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
+    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
+    extrinsics = as_extrinsics(tvec)
+    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+    color_legacy = np.asarray(projected.color.to_legacy())
+    outfile = outdir / f"color_{left_name.stem}.png"
+    outfile.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(outfile), color_legacy)
+    depth_legacy = np.asarray(projected.depth.to_legacy())
+    depth_file = outdir / f"depth_{left_name.stem}.png"
+    depth_file.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(depth_file), depth_legacy)
+    print(f"saved {outfile}")
+    print(f"saved {depth_file}")
+
+    assert outfile.lstat().st_size > 0
+
 
 if __name__ == "__main__":
     """
@@ -30,16 +53,4 @@ if __name__ == "__main__":
     left_image = skimage.io.imread(str(left_name))
     disparity = np.load(str(disparity_name))
 
-    stereo_camera = StereoCamera(baseline=120)
-    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
-    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
-    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
-    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
-    extrinsics = as_extrinsics(tvec)
-    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
-    color_legacy = np.asarray(projected.color.to_legacy())
-    outfile = outdir / "color_left_motorcycle.png"
-    outfile.parent.mkdir(exist_ok=True, parents=True)
-    safer_imsave(str(outfile), color_legacy)
-    print(f"saved {outfile}")
-    assert outfile.lstat().st_size > 0
+    gen_right_image(disparity, left_image, outdir, left_name, axis=axis)

--- a/scripts/sample_class.py
+++ b/scripts/sample_class.py
@@ -2,11 +2,13 @@ from pathlib import Path
 
 import numpy as np
 import skimage.io
+from tqdm import tqdm
 
 from disparity_view.o3d_project import gen_tvec, DEPTH_SCALE
 from disparity_view.o3d_project import as_extrinsics
 from disparity_view.projection_class import StereoCamera
 from disparity_view.util import safer_imsave
+from disparity_view.animation_gif import AnimationGif
 
 
 def gen_right_image(disparity, left_image, outdir, left_name, axis=0):
@@ -30,6 +32,54 @@ def gen_right_image(disparity, left_image, outdir, left_name, axis=0):
 
     assert outfile.lstat().st_size > 0
 
+def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Path, left_name: Path, axis=0):
+    """
+    save animation gif file
+
+    Args:
+        disparity: disparity image
+        left_image:left camera image
+        outdir: destination directory
+        left_name: file name of the left camera image
+    Returns：
+        None
+    """
+    assert axis in (0, 1, 2)
+
+    stereo_camera = StereoCamera(baseline=120)
+    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
+    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
+    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
+    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
+    extrinsics = as_extrinsics(tvec)
+    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+    color_legacy = np.asarray(projected.color.to_legacy())
+    outfile = outdir / f"color_{left_name.stem}.png"
+    outfile.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(outfile), color_legacy)
+    depth_legacy = np.asarray(projected.depth.to_legacy())
+    depth_file = outdir / f"depth_{left_name.stem}.png"
+    depth_file.parent.mkdir(exist_ok=True, parents=True)
+    safer_imsave(str(depth_file), depth_legacy)
+    print(f"saved {outfile}")
+    print(f"saved {depth_file}")
+
+
+    maker = AnimationGif()
+    n = 16
+    for i in tqdm(range(n + 1)):
+        scaled_baseline = stereo_camera.scaled_baseline()
+        tvec = gen_tvec(scaled_baseline * i / n, axis)
+        extrinsics = as_extrinsics(tvec)
+        projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
+        color_img = np.asarray(projected.color.to_legacy())
+        color_img = (color_img * 255).astype(np.uint8)
+        maker.append(color_img)
+
+    gifname = outdir / f"reproject_{left_name.stem}.gif"
+    gifname.parent.mkdir(exist_ok=True, parents=True)
+    maker.save(gifname)
+
 
 if __name__ == "__main__":
     """
@@ -52,5 +102,7 @@ if __name__ == "__main__":
 
     left_image = skimage.io.imread(str(left_name))
     disparity = np.load(str(disparity_name))
-
-    gen_right_image(disparity, left_image, outdir, left_name, axis=axis)
+    if args.gif:
+        make_animation_gif(disparity, left_image, outdir, left_name, axis=axis)
+    else:
+        gen_right_image(disparity, left_image, outdir, left_name, axis=axis)

--- a/scripts/sample_class.py
+++ b/scripts/sample_class.py
@@ -2,84 +2,8 @@ from pathlib import Path
 
 import numpy as np
 import skimage.io
-from tqdm import tqdm
 
-from disparity_view.o3d_project import gen_tvec, DEPTH_SCALE
-from disparity_view.o3d_project import as_extrinsics
-from disparity_view.projection_class import StereoCamera
-from disparity_view.util import safer_imsave
-from disparity_view.animation_gif import AnimationGif
-
-
-def gen_right_image(disparity, left_image, outdir, left_name, axis=0):
-    stereo_camera = StereoCamera(baseline=120)
-    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
-    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
-    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
-    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
-    extrinsics = as_extrinsics(tvec)
-    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
-    color_legacy = np.asarray(projected.color.to_legacy())
-    outfile = outdir / f"color_{left_name.stem}.png"
-    outfile.parent.mkdir(exist_ok=True, parents=True)
-    safer_imsave(str(outfile), color_legacy)
-    depth_legacy = np.asarray(projected.depth.to_legacy())
-    depth_file = outdir / f"depth_{left_name.stem}.png"
-    depth_file.parent.mkdir(exist_ok=True, parents=True)
-    safer_imsave(str(depth_file), depth_legacy)
-    print(f"saved {outfile}")
-    print(f"saved {depth_file}")
-
-    assert outfile.lstat().st_size > 0
-
-def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Path, left_name: Path, axis=0):
-    """
-    save animation gif file
-
-    Args:
-        disparity: disparity image
-        left_image:left camera image
-        outdir: destination directory
-        left_name: file name of the left camera image
-    Returns：
-        None
-    """
-    assert axis in (0, 1, 2)
-
-    stereo_camera = StereoCamera(baseline=120)
-    stereo_camera.set_camera_matrix(shape=disparity.shape, focal_length=1070)
-    stereo_camera.pcd = stereo_camera.generate_point_cloud(disparity, left_image)
-    scaled_baseline = stereo_camera.scaled_baseline()  # [mm]
-    tvec = gen_tvec(scaled_shift=scaled_baseline, axis=axis)
-    extrinsics = as_extrinsics(tvec)
-    projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
-    color_legacy = np.asarray(projected.color.to_legacy())
-    outfile = outdir / f"color_{left_name.stem}.png"
-    outfile.parent.mkdir(exist_ok=True, parents=True)
-    safer_imsave(str(outfile), color_legacy)
-    depth_legacy = np.asarray(projected.depth.to_legacy())
-    depth_file = outdir / f"depth_{left_name.stem}.png"
-    depth_file.parent.mkdir(exist_ok=True, parents=True)
-    safer_imsave(str(depth_file), depth_legacy)
-    print(f"saved {outfile}")
-    print(f"saved {depth_file}")
-
-
-    maker = AnimationGif()
-    n = 16
-    for i in tqdm(range(n + 1)):
-        scaled_baseline = stereo_camera.scaled_baseline()
-        tvec = gen_tvec(scaled_baseline * i / n, axis)
-        extrinsics = as_extrinsics(tvec)
-        projected = stereo_camera.project_to_rgbd_image(extrinsics=extrinsics)
-        color_img = np.asarray(projected.color.to_legacy())
-        color_img = (color_img * 255).astype(np.uint8)
-        maker.append(color_img)
-
-    gifname = outdir / f"reproject_{left_name.stem}.gif"
-    gifname.parent.mkdir(exist_ok=True, parents=True)
-    maker.save(gifname)
-
+from disparity_view.projection_class import gen_right_image, make_animation_gif
 
 if __name__ == "__main__":
     """


### PR DESCRIPTION
# why
- depthデータをグレースケールで保存する際の不具合があった。floatの最大値を1.0 と仮定していた。
# what
- 出力ファイル名がdepthを含むときには、最大値の値を仮定しない方法で、uint8に収まるようにした。
- 以前の実装を置き換える準備のために、２つの関数をモジュールファイルに移動した。

# 動作確認
- Jetsonでも以下の確認を実行
```
make test
cd scripts
python3 sample_class.py ../test/test-imgs/disparity-IGEV/left_motorcycle.npy ../test/test-imgs/left/left_motorcycle.png  --axis 2 
python3 sample_class.py ../test/test-imgs/disparity-IGEV/left_motorcycle.npy ../test/test-imgs/left/left_motorcycle.png --axis 2 --gif
 ```
 
