### PR TITLE
move class to o3d_project.py

### DIFF
--- a/disparity_view/o3d_project.py
+++ b/disparity_view/o3d_project.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Tuple
 
@@ -8,6 +9,7 @@ import cv2
 
 from tqdm import tqdm
 
+from . import CameraParameter
 from .animation_gif import AnimationGif
 from .util import dummy_camera_matrix, safer_imsave
 
@@ -145,3 +147,54 @@ def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Pa
     gifname = outdir / f"reproject_{left_name.stem}.gif"
     gifname.parent.mkdir(exist_ok=True, parents=True)
     maker.save(gifname)
+
+
+@dataclass
+class StereoCamera:
+    baseline: float = field(default=120.0)  # [mm]
+    left_camera_matrix: np.ndarray = field(default=None)
+    right_camera_matrix: np.ndarray = field(default=None)
+    extrinsics: np.ndarray = field(default=None)
+    depth_scale: float = DEPTH_SCALE
+    depth_max: float = DEPTH_MAX
+    pcd: o3d.t.geometry.PointCloud = field(default=None)
+    rgbd: o3d.t.geometry.RGBDImage = field(default=None)
+    shape: Tuple[float] = field(default=None)
+
+    def load_camera_parameter(self, json: Path):
+        """ """
+        self.left_camera_matrix = CameraParameter.load_json(json).to_matrix()
+        self.right_camera_matrix = self.left_camera_matrix
+
+    def set_camera_matrix(self, shape: np.ndarray, focal_length: float = 1070.0):
+        self.shape = shape
+        self.left_camera_matrix = o3d.core.Tensor(dummy_camera_matrix(shape, focal_length=focal_length))
+        self.right_camera_matrix = self.left_camera_matrix
+
+    def set_baseline(self, baseline=120):
+        self.baseline = baseline
+
+    def generate_point_cloud(self, disparity_map: np.ndarray, left_image: np.ndarray):
+        if disparity_map.shape[:2] != left_image.shape[:2]:
+            print(f"{disparity_map.shape=} {left_image.shape[:2]=}")
+        assert disparity_map.shape[:2] == left_image.shape[:2]
+        return generate_point_cloud(disparity_map, left_image, self.left_camera_matrix, self.baseline)
+
+    def project_to_rgbd_image(self, extrinsics=o3d.core.Tensor(np.eye(4, dtype=np.float32))):
+        height, width = self.shape[:2]
+        assert isinstance(width, int)
+        assert isinstance(height, int)
+        assert isinstance(self.left_camera_matrix, o3d.core.Tensor)
+        assert isinstance(self.right_camera_matrix, o3d.core.Tensor)
+        assert isinstance(extrinsics, o3d.core.Tensor) or isinstance(extrinsics, np.ndarray)
+        return self.pcd.project_to_rgbd_image(
+            width,
+            height,
+            intrinsics=self.left_camera_matrix,
+            extrinsics=extrinsics,
+            depth_scale=DEPTH_SCALE,
+            depth_max=DEPTH_MAX,
+        )
+
+    def scaled_baseline(self):
+        return self.baseline / DEPTH_SCALE

--- a/disparity_view/o3d_project.py
+++ b/disparity_view/o3d_project.py
@@ -4,14 +4,12 @@ from typing import Tuple
 
 import numpy as np
 import open3d as o3d
-import skimage.io
-import cv2
 
 from tqdm import tqdm
 
-from . import CameraParameter
 from .animation_gif import AnimationGif
 from .util import dummy_camera_matrix, safer_imsave
+from .zed_info import CameraParameter
 
 
 DEPTH_SCALE = 1000.0

--- a/disparity_view/projection_class.py
+++ b/disparity_view/projection_class.py
@@ -62,7 +62,6 @@ def make_animation_gif(disparity: np.ndarray, left_image: np.ndarray, outdir: Pa
     print(f"saved {outfile}")
     print(f"saved {depth_file}")
 
-
     maker = AnimationGif()
     n = 16
     for i in tqdm(range(n + 1)):

--- a/disparity_view/projection_class.py
+++ b/disparity_view/projection_class.py
@@ -1,69 +1,11 @@
 from pathlib import Path
-from dataclasses import dataclass, field
-from typing import Tuple
 
-import cv2
 import numpy as np
-import open3d as o3d
 from tqdm import tqdm
 
 from .animation_gif import AnimationGif
-from .util import dummy_camera_matrix, safer_imsave
 from .util import safer_imsave
-from .o3d_project import generate_point_cloud, gen_tvec, as_extrinsics
-from .o3d_project import DEPTH_MAX, DEPTH_SCALE
-from .zed_info import CameraParameter
-
-
-@dataclass
-class StereoCamera:
-    baseline: float = field(default=120.0)  # [mm]
-    left_camera_matrix: np.ndarray = field(default=None)
-    right_camera_matrix: np.ndarray = field(default=None)
-    extrinsics: np.ndarray = field(default=None)
-    depth_scale: float = DEPTH_SCALE
-    depth_max: float = DEPTH_MAX
-    pcd: o3d.t.geometry.PointCloud = field(default=None)
-    rgbd: o3d.t.geometry.RGBDImage = field(default=None)
-    shape: Tuple[float] = field(default=None)
-
-    def load_camera_parameter(self, json: Path):
-        """ """
-        self.left_camera_matrix = CameraParameter.load_json(json).to_matrix()
-        self.right_camera_matrix = self.left_camera_matrix
-
-    def set_camera_matrix(self, shape: np.ndarray, focal_length: float = 1070.0):
-        self.shape = shape
-        self.left_camera_matrix = o3d.core.Tensor(dummy_camera_matrix(shape, focal_length=focal_length))
-        self.right_camera_matrix = self.left_camera_matrix
-
-    def set_baseline(self, baseline=120):
-        self.baseline = baseline
-
-    def generate_point_cloud(self, disparity_map: np.ndarray, left_image: np.ndarray):
-        if disparity_map.shape[:2] != left_image.shape[:2]:
-            print(f"{disparity_map.shape=} {left_image.shape[:2]=}")
-        assert disparity_map.shape[:2] == left_image.shape[:2]
-        return generate_point_cloud(disparity_map, left_image, self.left_camera_matrix, self.baseline)
-
-    def project_to_rgbd_image(self, extrinsics=o3d.core.Tensor(np.eye(4, dtype=np.float32))):
-        height, width = self.shape[:2]
-        assert isinstance(width, int)
-        assert isinstance(height, int)
-        assert isinstance(self.left_camera_matrix, o3d.core.Tensor)
-        assert isinstance(self.right_camera_matrix, o3d.core.Tensor)
-        assert isinstance(extrinsics, o3d.core.Tensor) or isinstance(extrinsics, np.ndarray)
-        return self.pcd.project_to_rgbd_image(
-            width,
-            height,
-            intrinsics=self.left_camera_matrix,
-            extrinsics=extrinsics,
-            depth_scale=DEPTH_SCALE,
-            depth_max=DEPTH_MAX,
-        )
-
-    def scaled_baseline(self):
-        return self.baseline / DEPTH_SCALE
+from .o3d_project import gen_tvec, as_extrinsics, StereoCamera
 
 
 def gen_right_image(disparity, left_image, outdir, left_name, axis=0):

--- a/disparity_view/zed_info.py
+++ b/disparity_view/zed_info.py
@@ -65,10 +65,4 @@ class CameraParameter:
         return camera intrinsics matrix
         """
         assert isinstance(self.fx, float)
-        return np.array(
-            [
-                [self.fx, 0, self.cx],
-                [0, self.fy, self.cy],
-                [0, 0, 1]
-            ]
-        )
+        return np.array([[self.fx, 0, self.cx], [0, self.fy, self.cy], [0, 0, 1]])

--- a/test/test_imread.py
+++ b/test/test_imread.py
@@ -10,11 +10,12 @@ def test_imread():
     cvdepth = skimage.io.imread(depth_path)
     cvcolor = skimage.io.imread(color_path)
     print(f"{cvdepth.dtype=}")
-#    assert cvdepth.dtype in (np.uint16, np.uint32)
+    #    assert cvdepth.dtype in (np.uint16, np.uint32)
     assert len(cvdepth.shape) == 2
-#    assert cvcolor.dtype == np.uint8
+    #    assert cvcolor.dtype == np.uint8
     assert len(cvcolor.shape) == 3
     assert cvcolor.shape[2] in (3, 4)
+
 
 if __name__ == "__main__":
     test_imread()

--- a/test/test_o3d_project.py
+++ b/test/test_o3d_project.py
@@ -134,6 +134,8 @@ def test_gen_right_image():
     gen_right_image(disparity, left_image, Path("out"), left_name, axis=axis)
     outfile = Path("out") / "color_left_motorcycle.png"
     assert outfile.lstat().st_size > 0
+
+
 if __name__ == "__main__":
     test_o3d_reproject()
     test_gen_right_image()

--- a/test/test_projection_class.py
+++ b/test/test_projection_class.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 import numpy as np
 
-from disparity_view.o3d_project import gen_tvec, DEPTH_SCALE
+from disparity_view.o3d_project import gen_tvec, DEPTH_SCALE, StereoCamera
 from disparity_view.o3d_project import as_extrinsics
-from disparity_view.projection_class import StereoCamera
 from disparity_view.util import safer_imsave
 import skimage.io
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -20,5 +20,6 @@ def test_safer_imsave():
     img2 = skimage.io.imread(str(outfile))
     assert np.max(img2.flatten()) > 0
 
+
 if __name__ == "__main__":
     test_safer_imsave()

--- a/test/test_zed_info.py
+++ b/test/test_zed_info.py
@@ -42,6 +42,7 @@ def test_camera_param_create():
     assert isinstance(camera_parameter.cx, float)
     assert isinstance(camera_parameter.cy, float)
 
+
 @pytest.mark.skipif(no_zed_sdk, reason="ZED SDK(StereoLabs) is not installed.")
 def test_camera_param_create_to_marix():
     cam_info = get_zed_camerainfo()


### PR DESCRIPTION
# why
- 複数のモジュールファイルを分割がうまく分割されていないので、見通しを損ねている。
- また、partial initialization　を生じかねない。
# what
- CameraParameter クラスのメソッドをo3d_project.py に移動した。
- test/test*.py をreformatした。
