### PR TITLE
Feature/refactor zed info

### DIFF
--- a/disparity_view/__init__.py
+++ b/disparity_view/__init__.py
@@ -4,8 +4,4 @@ from .depth_to_normal import DepthToNormalMap
 from .o3d_project import project_from_left_and_disparity, gen_right_image
 from .o3d_project import make_animation_gif
 
-from .zed_info import (
-    get_width_height_fx_fy_cx_cy,
-    get_baseline,
-    CameraParameter,
-)
+from .zed_info import CameraParameter

--- a/disparity_view/zed_info.py
+++ b/disparity_view/zed_info.py
@@ -60,15 +60,6 @@ class CameraParameter:
     cy: float = 0.0  # [pixel]
     baseline: float = 0.0
 
-    def get_current_setting(self, cam_info):
-        """
-        Note:
-            cam_info = zed.get_camera_information()
-        """
-        left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-        self.width, self.height, self.fx, self.fy, self.cx, self.cy = get_width_height_fx_fy_cx_cy(left_cam_params)
-        self.baseline = get_baseline(cam_info)
-
     def save_json(self, name: Path):
         open(name, "wt").write(self.to_json())
 
@@ -83,8 +74,15 @@ class CameraParameter:
             cam_info = zed.get_camera_information()
         """
         left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-        width, height, fx, fy, cx, cy = get_width_height_fx_fy_cx_cy(left_cam_params)
-        baseline = get_baseline(cam_info)
+        width, height, fx, fy, cx, cy = (
+            left_cam_params.image_size.width,
+            left_cam_params.image_size.height,
+            left_cam_params.fx,
+            left_cam_params.fy,
+            left_cam_params.cx,
+            left_cam_params.cy,
+        )
+        baseline = left_cam_params.get_camera_baseline()
         return cls(width=width, height=height, fx=fx, fy=fy, cx=cx, cy=cy, baseline=baseline)
 
     def to_matrix(self) -> np.ndarray:

--- a/disparity_view/zed_info.py
+++ b/disparity_view/zed_info.py
@@ -12,28 +12,6 @@ from pathlib import Path
 
 import numpy as np
 
-def get_width_height_fx_fy_cx_cy(left_cam_params):
-    """
-    Note:
-        left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-    """
-    return (
-        left_cam_params.image_size.width,
-        left_cam_params.image_size.height,
-        left_cam_params.fx,
-        left_cam_params.fy,
-        left_cam_params.cx,
-        left_cam_params.cy,
-    )
-
-
-def get_baseline(cam_info) -> float:
-    """
-    Note:
-        cam_info = zed.get_camera_information()
-    """
-    return cam_info.camera_configuration.calibration_parameters.get_camera_baseline()
-
 
 @dataclass_json
 @dataclass

--- a/disparity_view/zed_info.py
+++ b/disparity_view/zed_info.py
@@ -24,9 +24,6 @@ class CameraParameter:
     camera_parameter.save_json(json_file)
     parameter = CameraParameter.load_json(json_file)
 
-    camera_parameter2 = CameraParameter()
-    camera_parameter2.get_current_setting(cam_info)
-
     camera_parameter3 = CameraParameter.create(cam_info)
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "disparity_view"
 description = "depth npy file viewer"
 readme = "README.md"
-version = "0.0.13"
+version = "0.0.14"
 authors = [
     {name = "katsunori-waragai", email="huyuhiko1128@gmail.com"},
     {name = "zhang chao", email = "zhang.chao@borgroid.co.jp"},

--- a/test/test_zed_info.py
+++ b/test/test_zed_info.py
@@ -30,34 +30,6 @@ def get_zed_camerainfo():
 
 
 @pytest.mark.skipif(no_zed_sdk, reason="ZED SDK(StereoLabs) is not installed.")
-def test_get_baseline():
-    cam_info = get_zed_camerainfo()
-    baseline = disparity_view.get_baseline(cam_info)
-    assert 110 < baseline < 130
-
-
-@pytest.mark.skipif(no_zed_sdk, reason="ZED SDK(StereoLabs) is not installed.")
-def test_get_fx_fy_cx_cy():
-    cam_info = get_zed_camerainfo()
-
-    left_cam_params = cam_info.camera_configuration.calibration_parameters.left_cam
-
-    width, height, fx, fy, cx, cy = disparity_view.get_width_height_fx_fy_cx_cy(left_cam_params)
-
-    assert isinstance(width, int)
-    assert isinstance(height, int)
-    assert isinstance(fx, float)
-    assert isinstance(fy, float)
-    assert isinstance(cx, float)
-    assert isinstance(cy, float)
-
-    assert fx > 0
-    assert fy > 0
-    assert cx > 0
-    assert cy > 0
-
-
-@pytest.mark.skipif(no_zed_sdk, reason="ZED SDK(StereoLabs) is not installed.")
 def test_camera_param_create():
     cam_info = get_zed_camerainfo()
 


### PR DESCRIPTION
# why
- zed_info.py がclass化されきっていない関数が残っていて、見通しを損ねている。
# what
- CameraParameter クラスのメソッドを改善することで、２つの関数を削除した。
- その関数に対応するテストを削除した
