### PR TITLE
renamed to create_camera_matrix()

### DIFF
--- a/disparity_view/o3d_project.py
+++ b/disparity_view/o3d_project.py
@@ -8,7 +8,7 @@ import open3d as o3d
 from tqdm import tqdm
 
 from .animation_gif import AnimationGif
-from .util import dummy_camera_matrix, safer_imsave
+from .util import create_camera_matrix, safer_imsave
 from .cam_param import CameraParameter
 
 
@@ -109,7 +109,7 @@ class StereoCamera:
 
     def set_camera_matrix(self, shape: np.ndarray, focal_length: float = 1070.0):
         self.shape = shape
-        self.left_camera_matrix = o3d.core.Tensor(dummy_camera_matrix(shape, focal_length=focal_length))
+        self.left_camera_matrix = o3d.core.Tensor(create_camera_matrix(shape, focal_length=focal_length))
         self.right_camera_matrix = self.left_camera_matrix
 
     def set_baseline(self, baseline=120):

--- a/disparity_view/util.py
+++ b/disparity_view/util.py
@@ -4,10 +4,9 @@ import numpy as np
 import open3d as o3d
 import skimage
 
-
-def dummy_camera_matrix(image_shape, focal_length: float = 1070.0) -> np.ndarray:
+def create_camera_matrix(image_shape, focal_length: float = 1070.0) -> np.ndarray:
     """
-    return dummy camera matrix
+    return camera matrix
 
     Note:
         If you change camera resolution, camera parameters also changes.

--- a/scripts/gen_ply.py
+++ b/scripts/gen_ply.py
@@ -4,7 +4,6 @@ import cv2
 import numpy as np
 import open3d as o3d
 
-from disparity_view.util import dummy_pinhole_camera_intrincic
 from disparity_view.o3d_project import StereoCamera
 
 def gen_ply(disparity: np.ndarray, left_image: np.ndarray, outdir: Path, left_name: Path, baseline=120.0):


### PR DESCRIPTION
# why
- 実際に利用している関数にdummy_というヘッダがついているのが誤解を生じやすい。
# what
- dummy_camera_matrix() をcreate_camera_matrix()と関数名を変更した。