### PR TITLE
remove_radius_outliers() if remove_outlier

### DIFF
--- a/scripts/gen_ply.py
+++ b/scripts/gen_ply.py
@@ -8,7 +8,7 @@ import skimage.io
 import disparity_view
 
 
-def gen_ply(disparity: np.ndarray, left_image: np.ndarray, cam_param, outdir: Path, left_name: Path):
+def gen_ply(disparity: np.ndarray, left_image: np.ndarray, cam_param, outdir: Path, left_name: Path, remove_outlier=False):
     """
     generate point cloud and save
     """
@@ -21,7 +21,11 @@ def gen_ply(disparity: np.ndarray, left_image: np.ndarray, cam_param, outdir: Pa
     outdir.mkdir(exist_ok=True, parents=True)
     plyname = outdir / f"{left_name.stem}.ply"
     print(f"{plyname=}")
-    pcd = stereo_camera.pcd.to_legacy()
+    if remove_outlier:
+        outlier_removed_pcd, _ = stereo_camera.pcd.remove_radius_outliers(nb_points=5, search_radius=0.02)  #
+        pcd = outlier_removed_pcd.to_legacy()
+    else:
+        pcd = stereo_camera.pcd.to_legacy()
     o3d.io.write_point_cloud(str(plyname), pcd, write_ascii=False, compressed=False, print_progress=True)
     print(f"saved {plyname}")
 


### PR DESCRIPTION
# why
- 点群の出力にartifactが多数含まれている。
# what
- Open3Dのremove_radius_outliers()を使えるようにした。
https://www.open3d.org/docs/latest/python_api/open3d.t.geometry.PointCloud.html#open3d.t.geometry.PointCloud.remove_radius_outliers
- それを処理に常時加えると遅くなるので、option引数で切り替えられるようにした。

