### PR TITLE
Feature/zed tool

### DIFF
--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -8,6 +8,7 @@ import disparity_view
 def get_zed_camerainfo():
     zed = sl.Camera()
     init_params = sl.InitParameters()
+    init_params.camera_resolution = sl.RESOLUTION.LAST
     status = zed.open(init_params)
     if status != sl.ERROR_CODE.SUCCESS:
         print(f"Error opening camera: {status}")

--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -1,21 +1,24 @@
 import sys
+import inspect
 
 import pyzed.sl as sl
 
 import disparity_view
 
+global zed
+zed = sl.Camera()
+for k, v in inspect.getmembers(zed):
+    print(k, v)
+
+init_params = sl.InitParameters()
+init_params.camera_resolution = sl.RESOLUTION.LAST
+status = zed.open(init_params)
+if status != sl.ERROR_CODE.SUCCESS:
+    print(f"Error opening camera: {status}")
+    sys.exit(1)
 
 def get_zed_camerainfo():
-    zed = sl.Camera()
-    init_params = sl.InitParameters()
-    init_params.camera_resolution = sl.RESOLUTION.LAST
-    status = zed.open(init_params)
-    if status != sl.ERROR_CODE.SUCCESS:
-        print(f"Error opening camera: {status}")
-        sys.exit(1)
-
     cam_info = zed.get_camera_information()
-    zed.close()
     return cam_info
 
 
@@ -33,7 +36,8 @@ def zed_camera_resolutions():
 
 
 def change_camera_resolution(new_resolution):
-    zed = sl.Camera()
+    if zed.is_opend():
+        zed.close()
     init_params = sl.InitParameters()
     init_params.camera_resolution = resolutions[new_resolution]
     status = zed.open(init_params)
@@ -52,7 +56,6 @@ if __name__ == "__main__":
     ZED SDKのインストール済みのマシンから、ZED2iにUSB接続していること。
     """
     import argparse
-    import inspect
     from pathlib import Path
 
     parser = argparse.ArgumentParser("save zed camera parameter")
@@ -84,3 +87,5 @@ if __name__ == "__main__":
     elif args.new_resolution:
         if args.new_resolution in resolutions.keys():
             change_camera_resolution(args.new_resolution)
+
+    zed.close()

--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -24,10 +24,11 @@ def get_width_height(cam_info):
     height = left_cam_params.image_size.height
     return width, height
 
+
 def zed_camera_resolutions():
     import inspect
-    return {k: v for k, v in inspect.getmembers(sl.RESOLUTION) if str(v).find("RESOLUTION") > -1 and k.find("__") == -1
-    }
+
+    return {k: v for k, v in inspect.getmembers(sl.RESOLUTION) if str(v).find("RESOLUTION") > -1 and k.find("__") == -1}
 
 
 def change_camera_resolution(new_resolution):

--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -7,9 +7,7 @@ import disparity_view
 
 def get_zed_camerainfo():
     zed = sl.Camera()
-
     init_params = sl.InitParameters()
-
     status = zed.open(init_params)
     if status != sl.ERROR_CODE.SUCCESS:
         print(f"Error opening camera: {status}")
@@ -31,14 +29,13 @@ def zed_camera_resolutions():
     return {k: v for k, v in inspect.getmembers(sl.RESOLUTION) if str(v).find("RESOLUTION") > -1 and k.find("__") == -1
     }
 
-if __name__ == "__main__":
-    """
-    ZED2iの現在のカメラの解像度に即したカメラパラメータをZED　SDKから取得してファイルに保存する。
-    ZED SDKのインストール済みのマシンから、ZED2iにUSB接続していること。
-    """
-    from pathlib import Path
 
-    cam_info = get_zed_camerainfo()
+def change_camera_resolution(new_resolution):
+    zed = sl.Camera()
+    init_params = sl.InitParameters()
+    init_params.camera_resolution = resolutions[new_resolution]
+    status = zed.open(init_params)
+    cam_info = zed.get_camera_information()
     camera_parameter = disparity_view.CameraParameter.create(cam_info)
     width, height = get_width_height(cam_info)
     outname = Path("out") / f"zed_{width}_{height}.json"
@@ -46,5 +43,36 @@ if __name__ == "__main__":
     camera_parameter.save_json(outname)
     print(f"saved {outname}")
 
-    for k, v in zed_camera_resolutions().items():
-        print(k, v)
+
+if __name__ == "__main__":
+    """
+    ZED2iの現在のカメラの解像度に即したカメラパラメータをZED　SDKから取得してファイルに保存する。
+    ZED SDKのインストール済みのマシンから、ZED2iにUSB接続していること。
+    """
+    import argparse
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser("save zed camera parameter")
+    parser.add_argument("--list", action="store_true", help="list resolutions")
+    parser.add_argument("--save", action="store_true", help="save current resolution json")
+    parser.add_argument("--new_resolution", help="change to new resolution")
+    args = parser.parse_args()
+
+    if args.save:
+        cam_info = get_zed_camerainfo()
+        camera_parameter = disparity_view.CameraParameter.create(cam_info)
+        width, height = get_width_height(cam_info)
+        outname = Path("out") / f"zed_{width}_{height}.json"
+        outname.parent.mkdir(exist_ok=True, parents=True)
+        camera_parameter.save_json(outname)
+        print(f"saved {outname}")
+        exit()
+
+    resolutions = zed_camera_resolutions()
+    if args.list:
+        for k, v in resolutions.items():
+            print(k, v)
+        exit()
+    elif args.new_resolution:
+        if args.new_resolution in resolutions.keys():
+            change_camera_resolution(args.new_resolution)

--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -26,6 +26,10 @@ def get_width_height(cam_info):
     height = left_cam_params.image_size.height
     return width, height
 
+def zed_camera_resolutions():
+    import inspect
+    return {k: v for k, v in inspect.getmembers(sl.RESOLUTION) if str(v).find("RESOLUTION") > -1 and k.find("__") == -1
+    }
 
 if __name__ == "__main__":
     """
@@ -41,3 +45,6 @@ if __name__ == "__main__":
     outname.parent.mkdir(exist_ok=True, parents=True)
     camera_parameter.save_json(outname)
     print(f"saved {outname}")
+
+    for k, v in zed_camera_resolutions().items():
+        print(k, v)

--- a/scripts/save_zed_camera_param.py
+++ b/scripts/save_zed_camera_param.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
     ZED SDKのインストール済みのマシンから、ZED2iにUSB接続していること。
     """
     import argparse
+    import inspect
     from pathlib import Path
 
     parser = argparse.ArgumentParser("save zed camera parameter")
@@ -58,8 +59,8 @@ if __name__ == "__main__":
     parser.add_argument("--new_resolution", help="change to new resolution")
     args = parser.parse_args()
 
+    cam_info = get_zed_camerainfo()
     if args.save:
-        cam_info = get_zed_camerainfo()
         camera_parameter = disparity_view.CameraParameter.create(cam_info)
         width, height = get_width_height(cam_info)
         outname = Path("out") / f"zed_{width}_{height}.json"
@@ -72,6 +73,11 @@ if __name__ == "__main__":
     if args.list:
         for k, v in resolutions.items():
             print(k, v)
+
+        width = cam_info.camera_configuration.resolution.width
+        height = cam_info.camera_configuration.resolution.height
+        print("## current resolution")
+        print(f"{width=} {height=}")
         exit()
     elif args.new_resolution:
         if args.new_resolution in resolutions.keys():


### PR DESCRIPTION
# why
- ZED2i のカメラの解像度設定の候補がわかる手段を提供していない。
# what
- scripts/save_zed_camera_param.py に引数を設定した。
```
python3 save_zed_camera_param.py -h    
usage: save zed camera parameter [-h] [--list] [--save] [--new_resolution NEW_RESOLUTION]

optional arguments:
  -h, --help            show this help message and exit
  --list                list resolutions
  --save                save current resolution json
  --new_resolution NEW_RESOLUTION
                        change to new resolution
```
