### PR TITLE
opencv-python==3.4.18.65 again

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ After `zed_capture` execution, you will have following folders.
 ```
 
 ## troubleshooting
+#### circular import case
 If you encounter any of the following errors, run the following shell script.
 ```commandline
 bash reinstall-opencv.sh
@@ -204,6 +205,8 @@ cv._registerMatType(Mat)
 AttributeError: partially initialized module 'cv2' has no attribute '_registerMatType' (most likely due to a circular import)
 ```
 
+#### If you need a newer version of opencv
+- Edit pyproject.toml [dependencies] for opencv.
 
 ## Note on StereoLabs ZED2i Camera
 - You can get stereo rectified left, right image pairs with timestamp.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">= 3.8"
 dependencies = [
     "dataclasses_json",
     "numpy<2",
-    "opencv-python>=3.4.18.65",
+    "opencv-python==3.4.18.65",
     "open3d>=0.16.0",
     "pillow>=10.1.0",
     "scikit-image",


### PR DESCRIPTION
# why
The following commit extends the range of opencv versions.
https://github.com/katsunori-waragai/disparity-view/pull/147

However, for the convenience of users, we decided that it is better to fix the version and not generate errors.

# what
- Again, we fixed the version.
- If you need a newer version, please rewrite pyproject.toml in README.md.