### PR TITLE
typehint is now list

### DIFF
--- a/disparity_view/animation_gif.py
+++ b/disparity_view/animation_gif.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
 
 import numpy as np
 from PIL import Image
@@ -15,7 +14,7 @@ class AnimationGif:
     maker.save(gifname)
     """
 
-    images: List = field(default_factory=list)
+    images: list = field(default_factory=list)
 
     def append(self, image: np.ndarray):
         "append image to list for animation gif"

--- a/disparity_view/o3d_project.py
+++ b/disparity_view/o3d_project.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Tuple
 
 import numpy as np
 import open3d as o3d
@@ -44,7 +43,7 @@ class StereoCamera:
     depth_max: float = DEPTH_MAX
     pcd: o3d.t.geometry.PointCloud = field(default=None)
     rgbd: o3d.t.geometry.RGBDImage = field(default=None)
-    shape: Tuple[float] = field(default=None)
+    shape: tuple[float] = field(default=None)
 
     @classmethod
     def create_from_camera_param(cls, camera_param: CameraParameter):

--- a/disparity_view/view.py
+++ b/disparity_view/view.py
@@ -8,7 +8,7 @@ library to view disparity npy files.
 import argparse
 import time
 from pathlib import Path
-from typing import Tuple
+
 
 import cv2
 import numpy as np
@@ -62,7 +62,7 @@ def as_matrix(chw_array: np.ndarray) -> np.ndarray:
     return np.reshape(chw_array, (H_, W_))
 
 
-def get_dirs(captured_dir: Path) -> Tuple[Path, Path, Path]:
+def get_dirs(captured_dir: Path) -> tuple[Path, Path, Path]:
     leftdir = captured_dir / "left"
     rightdir = captured_dir / "right"
     disparity_dir = captured_dir / "zed-disparity"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     {name = "zhang chao", email = "zhang.chao@borgroid.co.jp"},
 ]
 
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 dependencies = [
     "dataclasses_json",

--- a/test/test_o3d_project.py
+++ b/test/test_o3d_project.py
@@ -9,7 +9,6 @@ depth_max (float, optional, default=3.0) – Truncated at depth_max distance.
 
 """
 
-from typing import Tuple
 
 import open3d as o3d
 import numpy as np
@@ -21,7 +20,7 @@ from disparity_view import CameraParameter
 from disparity_view.util import safer_imsave
 
 
-def shape_of(image) -> Tuple[float, float]:
+def shape_of(image) -> tuple[float, float]:
     if isinstance(image, np.ndarray):
         return image.shape
     else:


### PR DESCRIPTION
# what
- After Python 3.9, typing.List, typing.Tuple are replaced by list, tuple
